### PR TITLE
Bugfix: String offset cast in RtmpStream.class::readByte

### DIFF
--- a/RtmpStream.class.php
+++ b/RtmpStream.class.php
@@ -1,7 +1,7 @@
 <?php
 class RtmpStream
 {
-	private $_index;
+	private $_index = 0;
 	private $_data;
 	
 	public function __construct($data = "")


### PR DESCRIPTION
Fixed a bug which lead to String offset cast in RtmpStream.class::readByte. Index was default null, which lead to problems when calling readByte.
